### PR TITLE
Use Qt sleep method instead of Windows specific one

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,3 +1,5 @@
+#include <QThread>
+
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
@@ -176,7 +178,7 @@ void MainWindow::on_btnClose_clicked()
 {
     on_btnStop_clicked();
 
-    Sleep(1000);
+    QThread::msleep(1000);
 
     port.close();
 


### PR DESCRIPTION
Thank you for this nice piece of software.

I had to make a small change to allow to build on Linux.
I have then used a Qt method to make it cross platform.